### PR TITLE
Limit the node_worker_pool creation to allowed names only

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -380,13 +380,13 @@ register(App, [{permissions, Permissions}|T]) ->
 register(App, [{auth_mod, {AuthType, AuthMod}}|T]) ->
     register_proplist({AuthType, AuthMod}, auth_mods),
     register(App, T);
-register(App, 
-            [{node_worker_pool, 
+register(App,
+            [{node_worker_pool,
                 {WorkerMod, PoolSize, WArgs, WProps, node_worker_pool}}|T]) ->
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, node_worker_pool),
     register(App, T);
-register(App, 
-            [{dscp_worker_pool, 
+register(App,
+            [{dscp_worker_pool,
                 {WorkerMod, PoolSize, WArgs, WProps, PoolType}}|T]) ->
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, PoolType),
     register(App, T).
@@ -409,11 +409,11 @@ register_mod(App, Module, Type) when is_atom(Type) ->
     end.
 
 register_pool(_App, WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType) ->
-    riak_core_node_worker_pool_sup:start_pool(WorkerMod,
-                                                PoolSize, 
-                                                WorkerArgs, 
-                                                WorkerProps,
-                                                PoolType).
+    ok = riak_core_node_worker_pool_sup:start_pool(WorkerMod,
+                                                   PoolSize,
+                                                   WorkerArgs,
+                                                   WorkerProps,
+                                                   PoolType).
 
 register_metadata(App, Value, Type) ->
     case application:get_env(riak_core, Type) of

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -1092,7 +1092,7 @@ mod_set_forwarding(Forward, State=#state{mod=Mod, modstate=ModState}) ->
 queue_work(PoolName, Work, From, VnodeWrkPool) ->
     PoolName0 =
         case PoolName of
-            queue -> node_worker_pool;
+            queue -> riak_core_node_worker_pool:nwp();
             PoolName -> PoolName
         end,
     case whereis(PoolName0) of


### PR DESCRIPTION
This change limits the name of a node_worker_pool to only those
allowed as defined riak_core_node_worker_pool:worker_pool(). Since an
app using riak_core may attempt to register a worker pool with any
name via riak_core:register, these changes will cause a crash at app
start up if a dissallowed name is used. The error will be a function
clause error on start_link. I'm not sure if it would be defensive
programming to make the error more explicit.

Although it may appear verbose, I also exposed the atom pool names as
functions, since then tools like xref can be used to ensure that pools
called from other applications use the correct allowed names.