### PR TITLE
Add stats for worker pools

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -1099,6 +1099,7 @@ queue_work(PoolName, Work, From, VnodeWrkPool) ->
         undefined ->
             lager:info("Using vnode pool as ~w pool is not registered",
                         [PoolName0]),
+            riak_core_stat:update({worker_pool, unregistered}),
             riak_core_vnode_worker_pool:handle_work(VnodeWrkPool, Work, From);
         _P ->
             riak_core_node_worker_pool:handle_work(PoolName0, Work, From)

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -58,6 +58,7 @@ start_link(WorkerMod,
 										?MODULE).
 	
 handle_work(Pid, Work, From) ->
+    riak_core_stat:update({worker_pool, vnode_pool}),
 	riak_core_worker_pool:handle_work(Pid, Work, From).
 
 stop(Pid, Reason) ->


### PR DESCRIPTION
Expose lists of names of pools from RCNWP to make life easier for
testing and generating stat names.